### PR TITLE
Make report sections update graph models silently, so render occurs a…

### DIFF
--- a/src/htdocs/js/renderer/nehrp2015/Nehrp2015Section_11_4_5.js
+++ b/src/htdocs/js/renderer/nehrp2015/Nehrp2015Section_11_4_5.js
@@ -115,7 +115,7 @@ var Nehrp2015Section_Section_11_4_5 = function (params) {
       data: result.get('sdSpectrum') || [],
       ss: result.get('sds'),
       s1: result.get('sd1')
-    });
+    }, {silent: true});
 
     return args;
   });

--- a/src/htdocs/js/renderer/nehrp2015/Nehrp2015Section_11_4_6.js
+++ b/src/htdocs/js/renderer/nehrp2015/Nehrp2015Section_11_4_6.js
@@ -64,7 +64,7 @@ var Nehrp2015Section_Section_11_4_6 = function (params) {
       data: result.get('smSpectrum') || [],
       ss: result.get('sms'),
       s1: result.get('sm1')
-    });
+    }, {silent: true});
 
     return args;
   });

--- a/src/htdocs/js/renderer/nehrp2015/Nehrp2015Section_Summary.js
+++ b/src/htdocs/js/renderer/nehrp2015/Nehrp2015Section_Summary.js
@@ -122,8 +122,8 @@ var Nehrp2015Section_Summary = function (params) {
     spectraDiv.appendChild(_smSpectrum.el);
     spectraDiv.appendChild(_sdSpectrum.el);
 
-    _smSpectrum.model.set({data: result.get('smSpectrum')||[]});
-    _sdSpectrum.model.set({data: result.get('sdSpectrum')||[]});
+    _smSpectrum.model.set({data: result.get('smSpectrum')||[]}, {silent: true});
+    _sdSpectrum.model.set({data: result.get('sdSpectrum')||[]}, {silent: true});
 
     return args;
   });


### PR DESCRIPTION
…fter in dom

Firefox silently threw an error when using svgelement.getBBox(), as part of the graph render process.

The graph models were being updated before the elements were added to the dom, even though there is a separate contentInDom method used for rendering once the elements were added.  This change skips the first render pass, and waits until elements are added.

