### PR TITLE
Make sure all seven columns are visible during print on tables

### DIFF
--- a/src/htdocs/css/util/_SiteAmplification.scss
+++ b/src/htdocs/css/util/_SiteAmplification.scss
@@ -17,7 +17,7 @@
   > tbody > tr > td {
     color: #333;
     text-align: center;
-    min-width: 100px;
+    min-width: 95px;
     padding: 3px;
 
     &.bound {


### PR DESCRIPTION
fixes usgs/earthquake-usdesign#55